### PR TITLE
TruthSorting_arrays.py

### DIFF
--- a/montecarlo/fax_waveform/TruthSorting_arrays.py
+++ b/montecarlo/fax_waveform/TruthSorting_arrays.py
@@ -162,7 +162,8 @@ def dataframe_to_root(dataframe, root_filename, treename='tree', mode='recreate'
                 branches[length_branch_name] = np.array([0])
                 branch_types[length_branch_name] = 'L'
             max_length = dataframe[length_branch_name].max()
-            first_element = dataframe[branch_name][0][0]
+            first_element_index = next((index for index, branch_length in enumerate(dataframe[length_branch_name]) if branch_length), None)
+            first_element = dataframe[branch_name][first_element_index][0]
             array_keys.append(branch_name)
 
         else:


### PR DESCRIPTION
The current `dataframe_to_root()` function seems to throw an error when the first row of the data contains no truth peaks. We don't want this, cause sometimes we produce data with no truth peaks by chance or to look at noise. A line was added here to avoid this - it defines the branch type in root by looking for the first non-zero row of the data.