### PR TITLE
Adding 'Corrections' to HAX_TREEMAKERS

### DIFF
--- a/montecarlo/run_sim.sh
+++ b/montecarlo/run_sim.sh
@@ -359,7 +359,7 @@ rm ${FAX_FILENAME}.*  # Peak-by-peak file with all photoionization info
 
 
 # hax stage
-HAX_TREEMAKERS="Basics Fundamentals DoubleScatter LargestPeakProperties TotalProperties Extended"
+HAX_TREEMAKERS="Basics Fundamentals Corrections DoubleScatter LargestPeakProperties TotalProperties Extended"
 
 # ROOT output
 (time haxer --main_data_paths ${OUTDIR} --input ${PAX_FILENAME##*/} --pax_version_policy loose --treemakers ${HAX_TREEMAKERS} --force_reload;) 2>&1 | tee ${HAX_FILENAME}.log

--- a/montecarlo/run_sim.sh
+++ b/montecarlo/run_sim.sh
@@ -359,7 +359,7 @@ rm ${FAX_FILENAME}.*  # Peak-by-peak file with all photoionization info
 
 
 # hax stage
-HAX_TREEMAKERS="Basics Fundamentals Corrections DoubleScatter LargestPeakProperties TotalProperties Extended"
+HAX_TREEMAKERS="Corrections Basics Fundamentals DoubleScatter LargestPeakProperties TotalProperties Extended"
 
 # ROOT output
 (time haxer --main_data_paths ${OUTDIR} --input ${PAX_FILENAME##*/} --pax_version_policy loose --treemakers ${HAX_TREEMAKERS} --force_reload;) 2>&1 | tee ${HAX_FILENAME}.log


### PR DESCRIPTION
We need to produce also the 'Corrections' minitree as the definition of cs2 moved from 'Basics' to 'Corrections'