### PR TITLE
Switch nSort to NEST model with correct field 

### DIFF
--- a/montecarlo/run_sim.sh
+++ b/montecarlo/run_sim.sh
@@ -78,10 +78,12 @@ if [[ ${SCIENCERUN} == 0 ]]; then
     DIFFUSION_CONSTANT=22.8  # cm^2/s
     DRIFT_VELOCITY=1.44      # um/ns
     ELECTRON_LIFETIME=450    # us
+    EFIELD=124               # V/cm
 else
     DIFFUSION_CONSTANT=31.73 # cm^2/s
     DRIFT_VELOCITY=1.335     # um/ns
     ELECTRON_LIFETIME=550    # us
+    EFIELD=0.082             # V/cm
 fi
 
 # runPatch argument corresponding to CONFIG variable above
@@ -300,7 +302,7 @@ else
     # nSort Stage
     NSORTEXEC=${RELEASEDIR}/nSort
     ln -sf ${RELEASEDIR}/data
-    (time ${NSORTEXEC} -s 2 -i ${G4_FILENAME};) 2>&1 | tee ${G4NSORT_FILENAME}.log
+    (time ${NSORTEXEC} -m 2 -f ${EFIELD} -s 2 -i ${G4_FILENAME};) 2>&1 | tee ${G4NSORT_FILENAME}.log
     if [ $? -ne 0 ];
     then
       terminate 12


### PR DESCRIPTION
Switching default nSort production to NEST emission model, which allows field variation (for SR1), instead of MarcW's XENON100 Leff/Qy model.  Probably a small effect, but should be checked.  This change can also be part of mc v1.0.0.  (No change to ER emission, which is already NEST and allows field variation.)

Should be merged with https://github.com/XENON1T/mc/pull/71.