### PR TITLE
Update directory structure

### DIFF
--- a/montecarlo/README.md
+++ b/montecarlo/README.md
@@ -96,7 +96,7 @@ which can queue several transfers and maximizes the bandwidth usage. More detail
 
 The official location will be ```/project/lgrandi/xenon1t/simulations```; please follow the existing directory structure within, e.g.:
 ~~~~
-/project/lgrandi/xenon1t/simulations/mc_v<MC_VERSION>/pax_v<PAX_VERSION>/<MC_FLAVOR>/<MC_CONFIG>
+/project/lgrandi/xenon1t/simulations/<MC_CONFIG>/mc_v<MC_VERSION>_<MC_FLAVOR>/fax_v<FAX_VERSION>/pax_v<PAX_VERSION>
 ~~~~
 and ensure you set the group appropriately
 ~~~~


### PR DESCRIPTION
- Move source (MC_CONFIG) to beginning of directory structure
- Append MC_FLAVOR to MC_VERSION
- Add FAX_VERSION, in case a different fax version is used to simulate than the reconstruction pax version

Should make it easier for an analyst of a specific source to see all available versions for that single source.

This is all done manually by each producer, so coordinators should enforce this structure.

Existing files should be moved when appropriate.