### PR TITLE
Update diffusion constant

### DIFF
--- a/montecarlo/config/SR1_parameters.ini
+++ b/montecarlo/config/SR1_parameters.ini
@@ -6,7 +6,7 @@ look_for_config_in_runs_db = False
 [WaveformSimulator]
 
 # S2 electron drift and extraction
-diffusion_constant_liquid =           31.73 * cm**2 / s  # Cathode at -8 kV, xenon:xenon1t:yuehuan:analysis:1sciencerun_s2width
+diffusion_constant_liquid =           29.35 * cm**2 / s  # Cathode at -8 kV, xenon:xenon1t:yuehuan:analysis:1sciencerun_s2width
 elr_gas_gap_length =                  2.66 * mm          # Average of level meters in run 3410 (should be checked for SR1)
 s2_secondary_sc_gain =                21.3                 # photons/SE, xenon:xenon1t:kmiller:sr1_se_waveform_shape
                                                          # (should be checked for SR1)


### PR DESCRIPTION
The outcome of the long discussion [here](https://github.com/XENON1T/processing/pull/43/files/e362e962a30ef101de44df5bd1092feaf1fa5e8d#diff-c72277e2818f920c0609e0fe4be24470R9) is that at least for now, we should be using 29.35 as the diffusion constant. The one chosen here comes from [lax](https://github.com/XENON1T/lax/blob/master/lax/lichens/sciencerun1.py#L211) and @weiyuehuan's [note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:yuehuan:analysis:1sciencerun_s2width#appendix_2drift_velocity_and_diffusion_constant), but doesn't reflect a multiplicative constant used to improve the fit to data.