### PR TITLE
Update MC scripts to allow for switching between XENONnT and XENON1T

### DIFF
--- a/montecarlo/mc_process.py
+++ b/montecarlo/mc_process.py
@@ -422,7 +422,7 @@ def run_main():
     args_exp = parser_exp.parse_known_args(sys.argv[1:])
     if args_exp[0].experiment is None:
        args_exp[0].experiment="XENON1T"
-    CONFIGS=args_exp[0].experiment
+    CONFIGS=get_configs(args_exp[0].experiment)
 
 
     parser = argparse.ArgumentParser(description="Create a set of files for doing MC simulation for X1T")

--- a/montecarlo/mc_process.py
+++ b/montecarlo/mc_process.py
@@ -68,6 +68,7 @@ def check_macro(macro_name, mc_version, experiment):
 
     :param macro_name: name of macro file
     :param mc_version: version of mc code to use
+    :param experiment: choice of XENON1T or XENONnT for MC
     :return: True if macro is available in OASIS for specified mc version
     """
     macro_location = os.path.join(MC_PATH, mc_version, 'macros', experiment,  macro_name)
@@ -155,6 +156,7 @@ def get_configs(experiment):
     Return a tuple with G4 macros that are available
     Warning: reads from latest MC version in /cvmfs
 
+    :param experiment: choice of XENON1T or XENONnT for MC
     :return: tuple with string of G4 macros available in latest MC version
     """
     try:
@@ -260,7 +262,7 @@ def generate_mc_workflow(mc_config,
     if experiment is None:
         experiment = "XENON1T"
 
-    if not (experiment=="XENON1T" or experiment=="XENONnT"):
+    if experiment not in ["XENON1T", "XENONnT"]:
         sys.stderr.write("Chosen experiment not implemented, " 
                          "exiting.\n")
         sys.exit(1)
@@ -410,7 +412,7 @@ def run_main():
     :return: exit code -- 0 on success, 1 otherwise
     """
     #Parser to choose experiment
-    parser_exp = argparse.ArgumentParser(description="Chose experiment")
+    parser_exp = argparse.ArgumentParser(description="Choose experiment")
 
     parser_exp.add_argument('--experiment', dest='experiment',
                         choices=["XENON1T", "XENONnT"],

--- a/montecarlo/mc_process.py
+++ b/montecarlo/mc_process.py
@@ -183,7 +183,6 @@ def get_configs(experiment):
 # needs to be set after functions defined
 MC_VERSIONS = get_mc_versions()
 PAX_VERSIONS = get_pax_versions()
-CONFIGS = get_configs("XENON1T")
 
 
 def generate_mc_workflow(mc_config,
@@ -410,12 +409,20 @@ def run_main():
 
     :return: exit code -- 0 on success, 1 otherwise
     """
+    #Parser to choose experiment
+    parser_exp = argparse.ArgumentParser(description="Chose experiment")
+
+    parser_exp.add_argument('--experiment', dest='experiment',
+                        choices=["XENON1T", "XENONnT"],
+                        action='store', default=None,
+                        help='experiment to use for MC')
+                        
+    args_exp = parser_exp.parse_known_args(sys.argv[1:])
+    CONFIGS=get_configs(args_exp[0].experiment)
+
 
     parser = argparse.ArgumentParser(description="Create a set of files for doing MC simulation for X1T")
     
-    parser.add_argument('--experiment', dest='experiment',
-                        action='store', default=None,
-                        help='experiment to use for MC')
     parser.add_argument('--flavor', dest='mc_flavor',
                         action='store', required=True,
                         choices=MC_FLAVORS,
@@ -468,43 +475,43 @@ def run_main():
                         help='macro to use for MC')
 
 
-    args = parser.parse_args(sys.argv[1:])
-    if args.num_events == 0:
+    args = parser.parse_known_args(sys.argv[1:])
+    if args[0].num_events == 0:
         sys.stdout.write("No events to generate, exiting")
         return 0
 
     output_directory = os.path.join(os.getcwd(), 'output')
     workflow_info = [0,
-                     args.num_events,
-                     args.mc_flavor,
-                     args.mc_config,
-                     args.batch_size,
-                     args.mc_version,
-                     args.fax_version,
-                     args.pax_version,
-                     args.sciencerun,
-                     args.preinit_macro,
-                     args.preinit_belt,
-                     args.preinit_efield,
-                     args.optical_setup,
-                     args.source_macro,
-                     args.experiment]
+                     args[0].num_events,
+                     args[0].mc_flavor,
+                     args[0].mc_config,
+                     args[0].batch_size,
+                     args[0].mc_version,
+                     args[0].fax_version,
+                     args[0].pax_version,
+                     args[0].sciencerun,
+                     args[0].preinit_macro,
+                     args[0].preinit_belt,
+                     args[0].preinit_efield,
+                     args[0].optical_setup,
+                     args[0].source_macro,
+                     args_exp[0].experiment]
 
-    workflow_info[0] = generate_mc_workflow(args.mc_config,
-                                            args.mc_flavor,
-                                            args.mc_version,
-                                            args.fax_version,
-                                            args.pax_version,
-                                            args.sciencerun,
-                                            args.start_job,
-                                            args.num_events,
-                                            args.batch_size,
-                                            args.preinit_macro,
-                                            args.preinit_belt,
-                                            args.preinit_efield,
-                                            args.optical_setup,
-                                            args.source_macro,
-                                            args.experiment)
+    workflow_info[0] = generate_mc_workflow(args[0].mc_config,
+                                            args[0].mc_flavor,
+                                            args[0].mc_version,
+                                            args[0].fax_version,
+                                            args[0].pax_version,
+                                            args[0].sciencerun,
+                                            args[0].start_job,
+                                            args[0].num_events,
+                                            args[0].batch_size,
+                                            args[0].preinit_macro,
+                                            args[0].preinit_belt,
+                                            args[0].preinit_efield,
+                                            args[0].optical_setup,
+                                            args[0].source_macro,
+                                            args_exp[0].experiment)
     if workflow_info[0] == 0:
         sys.stderr.write("Can't generate workflow, exiting\n")
         try:

--- a/montecarlo/mc_process.py
+++ b/montecarlo/mc_process.py
@@ -418,7 +418,9 @@ def run_main():
                         help='experiment to use for MC')
                         
     args_exp = parser_exp.parse_known_args(sys.argv[1:])
-    CONFIGS=get_configs(args_exp[0].experiment)
+    if args_exp[0].experiment is None:
+       args_exp[0].experiment="XENON1T"
+    CONFIGS=args_exp[0].experiment
 
 
     parser = argparse.ArgumentParser(description="Create a set of files for doing MC simulation for X1T")

--- a/montecarlo/run_sim.sh
+++ b/montecarlo/run_sim.sh
@@ -14,6 +14,7 @@
 # $12 - preinit_field
 # $13 - optical_setup
 # $14 - source_macro
+# $15 - experiment 
 
 function terminate {
 
@@ -67,6 +68,9 @@ if [[ "$8" == 1 ]]; then
     SAVE_RAW=$8
 fi
 
+# Set Experiment
+EXPERIMENT=$15
+
 # For configuring model parameters and cuts
 # Warning: Currently only used for G4-NEST, fax and lax, but NOT nSort emission models 
 SCIENCERUN=$9
@@ -109,7 +113,7 @@ RELEASEDIR=${CVMFSDIR}/releases/mc/${MCVERSION}
 PAX_LIB_DIR=${CVMFSDIR}/releases/anaconda/2.4/envs/pax_${PAXVERSION}/lib/
 
 # Setup Geant4 macros
-MACROSDIR=${RELEASEDIR}/macros
+MACROSDIR=${RELEASEDIR}/macros/${EXPERIMENT}
 
 PREINIT_MACRO=${10}
 if [[ -z $PREINIT_MACRO ]];
@@ -268,9 +272,10 @@ G4NSORT_FILENAME=${G4_FILENAME}_Sort
 
 # Geant4 stage
 G4EXEC=${RELEASEDIR}/xenon1t_${MCFLAVOR}
-ln -sf ${MACROSDIR} # For reading e.g. input spectra from CWD
+SPECTRADIR=${RELEASEDIR}/macros
+ln -sf ${SPECTRADIR} # For reading e.g. input spectra from CWD
 
-(time ${G4EXEC} -p ${PREINIT_MACRO} -b ${PREINIT_BELT} -e ${PREINIT_EFIELD} -s ${OPTICAL_SETUP} -f ${SOURCE_MACRO} -n ${NEVENTS} -o ${G4_FILENAME}.root;) 2>&1 | tee ${G4_FILENAME}.log
+(time ${G4EXEC} -p ${PREINIT_MACRO} -b ${PREINIT_BELT} -e ${PREINIT_EFIELD} -s ${OPTICAL_SETUP} -f ${SOURCE_MACRO} -n ${NEVENTS} -d ${EXPERIMENT} -o ${G4_FILENAME}.root;) 2>&1 | tee ${G4_FILENAME}.log
 if [ $? -ne 0 ];
 then
     terminate 10
@@ -278,6 +283,11 @@ fi
 
 # Skip the rest for optical photons
 if [[ ${CONFIG} == *"optPhot"* ]]; then
+    terminate 0
+fi
+
+# Skip the rest for XENONnT, will move along as XENONnT chain takes shape
+if [[ ${EXPERIMENT} == "XENONnT" ]]; then
     terminate 0
 fi
 


### PR DESCRIPTION
Added cases into the two macros to allow for switching between XENON1T and XENOnT geometries. At the moment all this should do is select the appropriate macro directory in the MC code, and exit the production chain after the G4 stage.

Will continue to propogate as other parts of the code get upgraded. Should be merged with  https://github.com/XENON1T/mc/pull/103. (Which is ready to merge as soon as this is approved.)