### PR TITLE
Update No PMT AP configs

### DIFF
--- a/montecarlo/fax_waveform_py/configs/NoPMTAfterpulses.ini
+++ b/montecarlo/fax_waveform_py/configs/NoPMTAfterpulses.ini
@@ -3,4 +3,4 @@
 pmt_afterpulse_types = {
     }
 
-each_pmt_afterpulse_types = None
+each_pmt_afterpulse_types = {}


### PR DESCRIPTION
With each_pmt_afterpulse_types = None 

This error occurs : 
 if 'each_pmt_afterpulse_types' in self.config and channel in self.config['each_pmt_afterpulse_types']:
TypeError: argument of type 'NoneType' is not iterable 

Change to each_pmt_afterpulse_types = {} solves it (thanks Joey for the help).